### PR TITLE
Make version validation pull from published source or use defined version from inputs

### DIFF
--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -52,11 +52,11 @@ jobs:
           mkdir results
           bundle exec kitchen test --destroy=always ${{ matrix.suite }}-ubuntu-1804 || true
       - name: Display our ${{ matrix.suite }} results summary
-        uses: mitre/saf_action@switchToJavascript
+        uses: mitre/saf_action@v1.1.0
         with:
           command_string: "view:summary -i spec/results/${{ matrix.suite }}-test-result.json"
       - name: Ensure the scan meets our ${{ matrix.suite }} results threshold
-        uses: mitre/saf_action@switchToJavascript
+        uses: mitre/saf_action@v1.1.0
         with:
           command_string: "validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml"
       - name: Save Test Result JSON

--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -51,6 +51,10 @@ jobs:
         run: |
           mkdir results
           bundle exec kitchen test --destroy=always ${{ matrix.suite }}-ubuntu-1804 || true
+      - name: Save Test Result JSON
+        uses: actions/upload-artifact@v2
+        with:
+          path: spec/results
       - name: Display our ${{ matrix.suite }} results summary
         uses: mitre/saf_action@v1.1.0
         with:
@@ -59,7 +63,3 @@ jobs:
         uses: mitre/saf_action@v1.1.0
         with:
           command_string: "validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml"
-      - name: Save Test Result JSON
-        uses: actions/upload-artifact@v2
-        with:
-          path: spec/results

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -67,6 +67,10 @@ jobs:
         run: bundle exec kitchen verify ${{ matrix.suite }}-ubuntu-1804 || true
       - name: Run Kitchen Destroy
         run: bundle exec kitchen destroy ${{ matrix.suite }}-ubuntu-1804 || true
+      - name: Save Test Result JSON
+        uses: actions/upload-artifact@v2
+        with:
+          path: spec/results
       - name: Display our ${{ matrix.suite }} results summary
         uses: mitre/saf_action@v1.1.0
         with:
@@ -75,7 +79,4 @@ jobs:
         uses: mitre/saf_action@v1.1.0
         with:
           command_string: "validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml"
-      - name: Save Test Result JSON
-        uses: actions/upload-artifact@v2
-        with:
-          path: spec/results
+

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -68,11 +68,11 @@ jobs:
       - name: Run Kitchen Destroy
         run: bundle exec kitchen destroy ${{ matrix.suite }}-ubuntu-1804 || true
       - name: Display our ${{ matrix.suite }} results summary
-        uses: mitre/saf_action@switchToJavascript
+        uses: mitre/saf_action@v1.1.0
         with:
           command_string: "view:summary -i spec/results/${{ matrix.suite }}-test-result.json"
       - name: Ensure the scan meets our ${{ matrix.suite }} results threshold
-        uses: mitre/saf_action@switchToJavascript
+        uses: mitre/saf_action@v1.1.0
         with:
           command_string: "validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml"
       - name: Save Test Result JSON

--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -50,6 +50,10 @@ jobs:
         run: bundle exec inspec check .
       - name: Run kitchen test
         run: bundle exec kitchen test --destroy=always ${{ matrix.suite }}-ubuntu-1804 || true
+      - name: Save Test Result JSON
+        uses: actions/upload-artifact@v2
+        with:
+          path: spec/results
       - name: Display our ${{ matrix.suite }} results summary
         uses: mitre/saf_action@v1.1.0
         with:
@@ -58,7 +62,3 @@ jobs:
         uses: mitre/saf_action@v1.1.0
         with:
           command_string: "validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml"
-      - name: Save Test Result JSON
-        uses: actions/upload-artifact@v2
-        with:
-          path: spec/results

--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -51,11 +51,11 @@ jobs:
       - name: Run kitchen test
         run: bundle exec kitchen test --destroy=always ${{ matrix.suite }}-ubuntu-1804 || true
       - name: Display our ${{ matrix.suite }} results summary
-        uses: mitre/saf_action@switchToJavascript
+        uses: mitre/saf_action@v1.1.0
         with:
           command_string: "view:summary -i spec/results/${{ matrix.suite }}-test-result.json"
       - name: Ensure the scan meets our ${{ matrix.suite }} results threshold
-        uses: mitre/saf_action@switchToJavascript
+        uses: mitre/saf_action@v1.1.0
         with:
           command_string: "validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml"
       - name: Save Test Result JSON

--- a/controls/V-56033.rb
+++ b/controls/V-56033.rb
@@ -38,8 +38,8 @@ control 'V-56033' do
   tag "rid": 'SV-70287r3_rule'
   tag "stig_id": 'SRG-APP-000456-WSR-000187'
   tag "fix_id": 'F-60911r2_fix'
-  tag "cci": ['CCI-002605']
-  tag "nist": ['SI-2 c']
+  tag "cci": 'CCI-002605'
+  tag "nist": 'SI-2 c'
 
   nginx_changelog = inspec.http('http://nginx.org/en/CHANGES').body.lines.map(&:chomp)
   nginx_changelog_clean = nginx_changelog.select { |line| line.include? 'Changes with nginx' }

--- a/inspec.yml
+++ b/inspec.yml
@@ -47,8 +47,7 @@ inputs:
   - name: "nginx_latest_version"
     description: "Latest supported Nginx version"
     type: String
-    value: '1.19.1'
-
+    
   - name: "nginx_owner"
     description: "The NGINX process owner"
     type: String

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -26,8 +26,6 @@ verifier:
   load_plugins: true
   inspec_tests:
     - path: .
-  # controls:
-  #   - "<%= ENV['INSPEC_CONTROL'] %>"
 
 platforms:
   - name: ubuntu-18.04
@@ -35,7 +33,7 @@ platforms:
       image: ubuntu:bionic-20220128
       provision_command:
         - apt-get update
-        - apt-get install -y systemd-sysv vim nginx w3m w3m-img 
+        - apt-get install -y systemd-sysv vim nginx w3m w3m-img
         - update-rc.d ssh defaults
         - service ssh start
         - update-rc.d nginx defaults

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -26,6 +26,8 @@ verifier:
   load_plugins: true
   inspec_tests:
     - path: .
+  # controls:
+  #   - "<%= ENV['INSPEC_CONTROL'] %>"
 
 platforms:
   - name: ubuntu-18.04

--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -37,6 +37,8 @@ verifier:
   load_plugins: true
   inspec_tests:
     - path: .
+  # controls:
+  #   - "<%= ENV['INSPEC_CONTROL'] %>"
 
 platforms:
   - name: ubuntu-18.04

--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -27,7 +27,7 @@ provisioner:
   additional_copy_path:
     - spec/ansible/nginx-hardening/vars
   extra_vars_file: /tmp/kitchen/vars/ec2.vars.yml
-  
+
 transport:
   name: ssh
 
@@ -37,8 +37,6 @@ verifier:
   load_plugins: true
   inspec_tests:
     - path: .
-  # controls:
-  #   - "<%= ENV['INSPEC_CONTROL'] %>"
 
 platforms:
   - name: ubuntu-18.04

--- a/kitchen.vagrant.yml
+++ b/kitchen.vagrant.yml
@@ -23,6 +23,8 @@ verifier:
   load_plugins: true
   inspec_tests:
     - path: .
+  # controls:
+  #   - "<%= ENV['INSPEC_CONTROL'] %>"
 
 platforms:
   - name: ubuntu-18.04

--- a/kitchen.vagrant.yml
+++ b/kitchen.vagrant.yml
@@ -23,8 +23,6 @@ verifier:
   load_plugins: true
   inspec_tests:
     - path: .
-  # controls:
-  #   - "<%= ENV['INSPEC_CONTROL'] %>"
 
 platforms:
   - name: ubuntu-18.04


### PR DESCRIPTION
- enhanced the version validation to go get the current nginx changelong and grab the latest version
- updated control to pass when either you are using the lastest version or if you are at least as good as the value defined by the input `nginx_version`

Fixes #6

Signed-off-by: Aaron Lippold <lippold@gmail.com>