### PR TITLE
Update workflows to use artifact actions v4 and replace the archived workflow …

### DIFF
--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -25,13 +25,13 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.7"
       - name: Setup caching
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -60,6 +60,6 @@ jobs:
         with:
           command_string: "validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml"
       - name: Save Test Result JSON
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: spec/results

--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Ensure the scan meets our ${{ matrix.suite }} results threshold
         uses: mitre/saf_action@v1
         with:
-          command_string: "validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml"
+          command_string: "validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -T ${{ matrix.suite }}.threshold.yml"
       - name: Save Test Result JSON
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -62,4 +62,5 @@ jobs:
       - name: Save Test Result JSON
         uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.suite }}-results
           path: spec/results

--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.1"
       - name: Setup caching
         uses: actions/cache@v4
         with:

--- a/.github/workflows/verify-docker.yml
+++ b/.github/workflows/verify-docker.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHEF_LICENSE: accept-silent
+      CHEF_LICENSE_KEY: ${{ secrets.SAF_CHEF_LICENSE_KEY }}
       KITCHEN_YAML: kitchen.docker.yml
     strategy:
       matrix:

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -32,7 +32,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
       - name: Clone full repository so we can push
         run: git fetch --prune --unshallow
       - name: Setup Ruby

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -33,7 +33,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SAF_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.SAF_AWS_REGION }}
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Clone full repository so we can push
         run: git fetch --prune --unshallow
       - name: Setup Ruby

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Ensure the scan meets our ${{ matrix.suite }} results threshold
         uses: mitre/saf_action@v1
         with:
-          command_string: 'validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml'
+          command_string: 'validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -T ${{ matrix.suite }}.threshold.yml'
       - name: Save Test Result JSON
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -28,9 +28,9 @@ jobs:
           AWS_SSH_KEY_ID: ${{ secrets.SAF_AWS_SSH_KEY_ID }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.SAF_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SAF_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.SAF_AWS_REGION }}
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Clone full repository so we can push

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHEF_LICENSE: accept-silent
+      CHEF_LICENSE_KEY: ${{ secrets.SAF_CHEF_LICENSE_KEY }}
       KITCHEN_YAML: kitchen.ec2.yml
     strategy:
       matrix:

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -17,15 +17,15 @@ jobs:
       KITCHEN_YAML: kitchen.ec2.yml
     strategy:
       matrix:
-        suite: ["vanilla", "hardened"]
+        suite: ['vanilla', 'hardened']
       fail-fast: false
     steps:
       - name: add needed packages
         run: sudo apt-get install -y jq
       - name: Configure AWS credentials
         env:
-          AWS_SUBNET_ID: ${{ secrets.AWS_SUBNET_ID }}
-          AWS_SSH_KEY_ID: ${{ secrets.AWS_SSH_KEY_ID }}
+          AWS_SUBNET_ID: ${{ secrets.SAF_AWS_SUBNET_ID }}
+          AWS_SSH_KEY_ID: ${{ secrets.SAF_AWS_SSH_KEY_ID }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7"
+          ruby-version: '2.7'
       # - name: Setup caching
       #   uses: actions/cache@v4
       #   with:
@@ -57,7 +57,7 @@ jobs:
       - name: Update profile.json in the repository
         uses: stefanzweifel/git-auto-commit-action@v4.1.0
         with:
-          commit_message: "Updating profile.json in the repository"
+          commit_message: 'Updating profile.json in the repository'
           branch: ${{ github.branch }}
       - name: Run Kitchen Create
         run: bundle exec kitchen create ${{ matrix.suite }}-ubuntu-1804 || true
@@ -70,11 +70,11 @@ jobs:
       - name: Display our ${{ matrix.suite }} results summary
         uses: mitre/saf_action@v1
         with:
-          command_string: "view:summary -i spec/results/${{ matrix.suite }}-test-result.json"
+          command_string: 'view:summary -i spec/results/${{ matrix.suite }}-test-result.json'
       - name: Ensure the scan meets our ${{ matrix.suite }} results threshold
         uses: mitre/saf_action@v1
         with:
-          command_string: "validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml"
+          command_string: 'validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml'
       - name: Save Test Result JSON
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -78,4 +78,5 @@ jobs:
       - name: Save Test Result JSON
         uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.suite }}-results
           path: spec/results

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
       # - name: Setup caching
       #   uses: actions/cache@v4
       #   with:

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -32,15 +32,15 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Clone full repository so we can push
         run: git fetch --prune --unshallow
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.7"
       # - name: Setup caching
-      #   uses: actions/cache@v2
+      #   uses: actions/cache@v4
       #   with:
       #     path: vendor/bundle
       #     key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -76,6 +76,6 @@ jobs:
         with:
           command_string: "validate:threshold -i spec/results/${{ matrix.suite }}-test-result.json -F ${{ matrix.suite }}.threshold.yml"
       - name: Save Test Result JSON
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: spec/results


### PR DESCRIPTION
…actions/setup-ruby@v1 with ruby/setup-ruby@v1

Changes made
- Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025.
- Also actions/setup-ruby is archived and has been recommended instead to use ruby/setup-ruby
- actions/cache is recommended to be [updated from v2 to either v3 or v4](https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes) (picked v4)